### PR TITLE
Improve and export types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -57,7 +57,7 @@ interface HistoryInterface {
   getList(options: HistoryListOptions): Promise<HistoryEntry[]> | Promise<never>
 }
 
-type HistoryListOptions = {
+export type HistoryListOptions = {
   accountId: string;
   from?: string;
   to?: string;
@@ -70,7 +70,7 @@ interface TransactionsInterface {
   getOne(options: TransactionOptions): Promise<Transaction> | Promise<never>
 }
 
-type TransactionsOptions = {
+export type TransactionsOptions = {
   accountId: string;
   ticker?: string;
   from?: string;
@@ -83,12 +83,12 @@ type TransactionsOptions = {
   exclude_fields?: string;
 }
 
-type TransactionOptions = {
+export type TransactionOptions = {
   accountId: string;
   txId: string;
 }
 
-type APIConfig = {
+export type APIConfig = {
   clientId: string;
   /** secret required only for server-side **/
   secret?: string;
@@ -105,11 +105,11 @@ type APIConfig = {
   hideWalletConnectWallets?: boolean;
 }
 
-type TokenOptions = {
+export type TokenOptions = {
   minimumLifetime: number;
 }
 
-type ConnectOptions = {
+export type ConnectOptions = {
   provider?: string;
   accountId?: string;
   state?: string;
@@ -127,7 +127,7 @@ type ConnectOptions = {
 }
 
 
-type ConnectDataOptions = {
+export type ConnectDataOptions = {
   provider?: string;
   accountId?: string;
   state?: string;
@@ -144,7 +144,7 @@ type ConnectDataOptions = {
   hideWalletConnectWallets?: boolean;
 };
 
-type ConnectData = {
+export type ConnectData = {
   url: string;
   token: string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -102,7 +102,7 @@ type APIConfig = {
     headers?: object;
     params?: object;
   }
-  hideWalletConnectWallets: boolean | undefined;
+  hideWalletConnectWallets?: boolean;
 }
 
 type TokenOptions = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -110,37 +110,39 @@ type TokenOptions = {
 }
 
 type ConnectOptions = {
-  provider: string;
-  accountId: string;
-  lang: string;
-  providerCategories: string;
-  providers: Array<string> | undefined;
-  theme: string | undefined;
-  providersPerLine: number | undefined;
-  syncNfts: boolean | undefined;
-  features: string | undefined;
-  multiWallet: boolean | undefined;
-  hideWalletConnectWallets: boolean | undefined;
+  provider?: string;
+  accountId?: string;
+  state?: string;
+  origin?: string;
+  lang?: string;
+  redirectURI?: string;
+  syncNfts?: boolean;
+  providerCategories?: string[];
+  providers?: string[];
+  theme?: 'light' | 'dark';
+  providersPerLine?: '1' | '2';
+  features?: any;
+  multiWallet?: boolean;
+  hideWalletConnectWallets?: boolean;
 }
 
 
 type ConnectDataOptions = {
-  provider: string;
-  accountId: string;
-  lang: string;
-  providerCategories: string;
-  providers: Array<string> | undefined;
-  theme: string | undefined;
-  providersPerLine: number | undefined;
-  syncNfts: boolean | undefined;
-  features: string | undefined;
-  multiWallet: boolean | undefined;
-  hideWalletConnectWallets: boolean | undefined;
-
-  origin: string | undefined;
-  state: string;
-  redirectURI: Array<string> | undefined;
-}
+  provider?: string;
+  accountId?: string;
+  state?: string;
+  origin?: string;
+  lang?: string;
+  redirectURI?: string;
+  syncNfts?: boolean;
+  providerCategories?: string[];
+  providers?: string[];
+  theme?: 'light' | 'dark';
+  providersPerLine?: '1' | '2';
+  features?: any;
+  multiWallet?: boolean;
+  hideWalletConnectWallets?: boolean;
+};
 
 type ConnectData = {
   url: string;


### PR DESCRIPTION
### This PR
- [x] Improves types for 
- ConnectOptions
- ConnectDataOptions
- [x] Sets `hideWalletConnectWallets` optional type for `APIConfig` type for backwards compatibility with existing TS implementations 
- [x] Exports types so they can be reused in TS projects 