### PR TITLE
Adding support for duplicate account

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,69 @@ user.reconnect('ACCOUNT_ID', {
 });
 ```
 
+### Handling Duplicate Connections
+
+When a user tries to connect an account that is already linked, Vezgo signals a `DUPLICATE_CONNECTION` conflict. The response always includes `existing_institution_id` — the Vezgo account ID of the already-linked connection — so you can surface or redirect to it in your UI.
+
+#### Via Vezgo Connect (widget)
+
+The `onError` callback receives an error object with `type: 'DUPLICATE_CONNECTION'` and `existing_institution_id`:
+
+```javascript
+user.connect({
+  // options
+}).onError((error) => {
+  if (error && error.type === 'DUPLICATE_CONNECTION') {
+    console.log('Already linked account ID:', error.existing_institution_id);
+    // e.g. highlight or navigate to the existing account in your UI
+    return;
+  }
+
+  console.error('Connection error:', error);
+});
+```
+
+The same check applies in `user.reconnect()`:
+
+```javascript
+user.reconnect('ACCOUNT_ID').onError((error) => {
+  if (error && error.type === 'DUPLICATE_CONNECTION') {
+    console.log('Already linked account ID:', error.existing_institution_id);
+    return;
+  }
+
+  console.error('Reconnection error:', error);
+});
+```
+
+#### Via direct API (409 Conflict)
+
+When an API call returns **409 Conflict**, the SDK throws a `DuplicateConnectionError`. Import the class to handle it by type:
+
+```javascript
+import Vezgo, { DuplicateConnectionError } from 'vezgo-sdk-js';
+
+try {
+  await user.accounts.sync('ACCOUNT_ID');
+} catch (err) {
+  if (err instanceof DuplicateConnectionError) {
+    console.log(err.message);                        // human-readable description
+    console.log(err.existing_institution_id);        // ID of the already-linked account
+    // e.g. redirect the user to the existing account
+    return;
+  }
+
+  throw err;
+}
+```
+
+`DuplicateConnectionError` properties:
+
+| Property | Description |
+|---|---|
+| `message` | Human-readable conflict description from the API (e.g. `"This connection is already linked to your account."`) |
+| `existing_institution_id` | Vezgo account ID of the already-linked connection |
+
 ### User APIs
 
 These methods return user data and thus require a Vezgo SDK User instance. They automatically fetch a new token if necessary so you would not be bothered with tokens logic.

--- a/example/basic/main.js
+++ b/example/basic/main.js
@@ -91,6 +91,15 @@ $(document).ready(() => {
       })
       .onError((error) => {
         console.log('connection error', error);
+
+        if (error && error.type === 'DUPLICATE_CONNECTION') {
+          const msg = `This connection is already linked. Existing account ID: ${error.existing_institution_id}`;
+          $('#response_heading').html(msg);
+          $('#connection_error strong').text(msg);
+          $('#account_id_mod').val(error.existing_institution_id);
+          return;
+        }
+
         $('#response_heading').html(`Error connecting account: ${JSON.stringify(error)}`);
         $('#connection_error strong').text(error.message);
       });
@@ -122,6 +131,15 @@ $(document).ready(() => {
       })
       .onError((error) => {
         console.log('reconnection error', error);
+
+        if (error && error.type === 'DUPLICATE_CONNECTION') {
+          const msg = `This connection is already linked. Existing account ID: ${error.existing_institution_id}`;
+          $('#response_heading').html(msg);
+          $('#connection_error strong').text(msg);
+          $('#account_id_mod').val(error.existing_institution_id);
+          return;
+        }
+
         $('#response_heading').html(`Error reconnecting account: ${JSON.stringify(error)}`);
         $('#connection_error strong').text(error.message);
       });

--- a/example/wealthica-direct-api/src/components/ConnectAccount.vue
+++ b/example/wealthica-direct-api/src/components/ConnectAccount.vue
@@ -205,7 +205,9 @@ function onInstitutionError(institution, error) {
   }
 
   if (error.status === 409) {
-    errorMessage.value = "Account can't be connected while syncing. Please try again later.";
+    const existingId = error.data?.existing_institution_id;
+    errorMessage.value = error.data?.message || 'This connection is already linked to your account.';
+    if (existingId) errorMessage.value += ` Existing account ID: ${existingId}`;
     store.institution = null;
     return;
   }

--- a/src/api.js
+++ b/src/api.js
@@ -383,6 +383,13 @@ class API {
         break;
       }
 
+      case 'ERROR': {
+        // Structured error event with a typed payload (e.g. DUPLICATE_CONNECTION).
+        // result.data = { type, existing_institution_id, error, ... }
+        this._triggerCallback(CALLBACK_ERROR, result.data);
+        break;
+      }
+
       case 'close': {
         // Widget closed by user action, close right away
         this._closeWidgetWithError(400, 'Connection closed');

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,8 @@
+export class DuplicateConnectionError extends Error {
+  constructor({ message, existing_institution_id } = {}) {
+    super(message || 'This connection is already linked to your account.');
+    this.name = 'DuplicateConnectionError';
+    // eslint-disable-next-line camelcase
+    this.existing_institution_id = existing_institution_id;
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,13 @@ export declare var Vezgo: {
   init(config: APIConfig): APIInterface;
 };
 
+export declare class DuplicateConnectionError extends Error {
+  name: 'DuplicateConnectionError';
+  /** The Vezgo account ID of the already-linked connection that caused the conflict. */
+  existing_institution_id: string;
+  constructor(data: { message?: string; existing_institution_id?: string });
+}
+
 export interface APIInterface {
   constructor(config: APIConfig);
   __init(): APIInterface;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import API from './api';
+export { DuplicateConnectionError } from './errors';
 
 class Vezgo {
    

--- a/src/resources/accounts.js
+++ b/src/resources/accounts.js
@@ -1,4 +1,12 @@
 import { getQueryString } from '../utils';
+import { DuplicateConnectionError } from '../errors';
+
+function throwOnError(response) {
+  if (!response.ok) {
+    if (response.status === 409) throw new DuplicateConnectionError(response.data || {});
+    throw response.originalError;
+  }
+}
 
 class Accounts {
   constructor(api) {
@@ -11,7 +19,7 @@ class Accounts {
     if (query) url = `${url}?${query}`;
 
     const response = await this.api.get(url);
-    if (!response.ok) throw response.originalError;
+    throwOnError(response);
 
     return response.data;
   }
@@ -24,7 +32,7 @@ class Accounts {
     if (query) url = `${url}?${query}`;
 
     const response = await this.api.get(url);
-    if (!response.ok) throw response.originalError;
+    throwOnError(response);
 
     return response.data;
   }
@@ -33,7 +41,7 @@ class Accounts {
     if (!id || typeof id !== 'string') throw new Error('Please provide a valid Vezgo account id.');
 
     const response = await this.api.post(`/accounts/${id}/sync`, {});
-    if (!response.ok) throw response.originalError;
+    throwOnError(response);
 
     return response.data;
   }
@@ -42,7 +50,7 @@ class Accounts {
     if (!id || typeof id !== 'string') throw new Error('Please provide a valid Vezgo account id.');
 
     const response = await this.api.delete(`/accounts/${id}`);
-    if (!response.ok) throw response.originalError;
+    throwOnError(response);
   }
 }
 


### PR DESCRIPTION
# Add `DUPLICATE_CONNECTION` error handling

## Summary

Adds first-class handling for duplicate connection errors across both the Vezgo Connect widget and the direct API path.

**Widget (`postMessage`):** The connect widget fires an uppercase `'ERROR'` event with a structured payload for typed errors. Previously this fell through to `onEvent` instead of `onError`. A new `case 'ERROR':` branch in `_onMessage` now routes it correctly to the `onError` callback, so callers receive `{ type: 'DUPLICATE_CONNECTION', existing_institution_id, error }` directly.

**Direct API (409 Conflict):** Adds a `DuplicateConnectionError` class (exported from the package root) and a shared `throwOnError` helper in the Accounts resource. All account methods (`getList`, `getOne`, `sync`, `remove`) now use the helper, which converts any 409 response into a `DuplicateConnectionError` carrying the `message` and `existing_institution_id` from the API response body. Other failures continue to throw `originalError` as before.

---

## Changes

- **`src/errors.js`** *(new)* — `DuplicateConnectionError` extending `Error`, with `existing_institution_id` and a sensible default message.
- **`src/api.js`** — new `case 'ERROR':` in `_onMessage` to handle the widget's structured uppercase error events.
- **`src/resources/accounts.js`** — `throwOnError` helper replacing inline `if (!response.ok)` checks; converts 409 → `DuplicateConnectionError`.
- **`src/index.js`** — re-exports `DuplicateConnectionError` as a named export.
- **`src/index.d.ts`** — TypeScript declaration for `DuplicateConnectionError`.
- **`example/basic/main.js`** — `onError` callbacks in both `connect` and `reconnect` now detect `DUPLICATE_CONNECTION` and pre-fill the account ID field with `existing_institution_id`.
- **`example/wealthica-direct-api/src/components/ConnectAccount.vue`** — 409 handler updated to read `message` and `existing_institution_id` from the API response body instead of showing a hardcoded string.
- **`README.md`** — new "Handling Duplicate Connections" section with code examples for both the widget and direct API paths.

---

## How to test

### Widget path

Attempt to connect a provider that is already linked for the user via `user.connect()` and verify `onError` is called (not `onEvent`) with the correct payload:

```js
user.connect().onError((error) => {
  // error.type          === 'DUPLICATE_CONNECTION'
  // error.existing_institution_id  === '<id of already-linked account>'
  console.log(error.type, error.existing_institution_id);
});
```

### Direct API path

```js
import Vezgo, { DuplicateConnectionError } from 'vezgo-sdk-js';

try {
  await user.accounts.sync('ACCOUNT_ID'); // trigger a 409 on any accounts method
} catch (err) {
  console.assert(err instanceof DuplicateConnectionError);
  console.assert(typeof err.existing_institution_id === 'string');
  console.log(err.message);                 // human-readable description from API
  console.log(err.existing_institution_id); // ID of the already-linked account
}
```