### PR TITLE
[VP-999] Fix Connect widget close on non-terminal ERROR + CJS/UMD interop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,14 +58,37 @@ Two Vite configs produce three outputs:
 
 ## Release Process
 
-Published to npm as `vezgo-sdk-js` (see `name` in `package.json`).
+Published to npm as `vezgo-sdk-js` (see `name` in `package.json`). Releases can be cut from either `master` or a feature branch — the steps below assume you're already on the branch that has the change committed.
 
 ```bash
+# 1. Use Node 22 (engines: node >= 18; Node 22 is what CI/release tooling uses)
+nvm use 22
+
+# 2. Bump version — creates a "X.Y.Z" commit and a matching "vX.Y.Z" tag
 npm version patch        # or minor / major
-git push && git push --tags
-npm publish              # `prepublishOnly` runs the build automatically
+
+# 3. Push the version-bump commit and the tag
+git push origin <current-branch>
+git push origin --tags
+
+# 4. Confirm you're logged in to npm (the publish account must have access to the `vezgo-sdk-js` package)
+npm whoami               # if this errors, run:
+npm login                # follow the browser/OTP prompt
+
+# 5. Publish — `prepublishOnly` runs `npm run build` automatically before upload
+npm publish
+
+# 6. Verify the version-specific page is live
+open https://www.npmjs.com/package/vezgo-sdk-js/v/<version>
 ```
 
-Verify the new version is live on https://www.npmjs.com/package/vezgo-sdk-js.
+There is no separate staging environment — every published version is immediately available to all consumers. The standard local-verification path is:
 
-There is no separate staging environment for this package — every published version is available to all consumers. Test changes locally with `npm link` or by pointing a consumer at a tarball before publishing.
+```bash
+cd example/basic
+rm -rf node_modules
+npm install              # installs the just-published version via the `^` range in package.json
+npm start                # visit http://localhost:3001 and exercise the change
+```
+
+If the release was cut from a feature branch, remember to merge that branch back into `master` once verified so master and npm stay in sync.

--- a/__tests__/user.instance.browser.js
+++ b/__tests__/user.instance.browser.js
@@ -116,4 +116,59 @@ describe('Vezgo User instance (Browser)', () => {
   c.testGetTokenBehavior.bind(this)({ isBrowser: true });
   c.testAutoRefreshBehavior.bind(this)({ isBrowser: true });
   c.testGetConnectDataBehavior.bind(this)({ isBrowser: true });
+
+  describe('Connect widget message handling', () => {
+    beforeEach(() => {
+      this.onConnection = vi.fn();
+      this.onError = vi.fn();
+      this.onEvent = vi.fn();
+      this.user.onConnection(this.onConnection);
+      this.user.onError(this.onError);
+      this.user.onEvent(this.onEvent);
+      // Simulate an open widget so _triggerCallback actually invokes the callbacks.
+      this.user._widgetOpened = true;
+      this.user._widgetActive = true;
+    });
+
+    const send = (payload) => this.user._onMessage({
+      origin: 'https://connect.vezgo.com',
+      data: JSON.stringify(payload),
+    });
+
+    test('ERROR/DUPLICATE_CONNECTION calls onError and marks the widget inactive', () => {
+      const data = { type: 'DUPLICATE_CONNECTION', existing_institution_id: 'abc' };
+      send({ vezgo: true, event: 'ERROR', data });
+      expect(this.onError).toHaveBeenCalledWith(data);
+      expect(this.onEvent).not.toHaveBeenCalled();
+      expect(this.user._widgetActive).toBe(false);
+    });
+
+    test('ERROR/INVALID_CREDENTIALS calls onEvent and keeps the widget open', () => {
+      const data = { type: 'INVALID_CREDENTIALS', error: { name: 'LoginFailedError' } };
+      send({ vezgo: true, event: 'ERROR', data });
+      expect(this.onEvent).toHaveBeenCalledWith('ERROR', data);
+      expect(this.onError).not.toHaveBeenCalled();
+      expect(this.user._widgetActive).toBe(true);
+    });
+
+    test('ERROR/SECURITY_QUESTION_REQUIRED calls onEvent and keeps the widget open', () => {
+      const data = { type: 'SECURITY_QUESTION_REQUIRED' };
+      send({ vezgo: true, event: 'ERROR', data });
+      expect(this.onEvent).toHaveBeenCalledWith('ERROR', data);
+      expect(this.onError).not.toHaveBeenCalled();
+      expect(this.user._widgetActive).toBe(true);
+    });
+
+    test('legacy lowercase error event still calls onError and closes the widget', () => {
+      send({ vezgo: true, event: 'error', error: { message: 'boom' } });
+      expect(this.onError).toHaveBeenCalledWith({ message: 'boom' });
+      expect(this.user._widgetActive).toBe(false);
+    });
+
+    test('messages without vezgo flag are ignored', () => {
+      send({ event: 'ERROR', data: { type: 'INVALID_CREDENTIALS' } });
+      expect(this.onError).not.toHaveBeenCalled();
+      expect(this.onEvent).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/example/basic/package-lock.json
+++ b/example/basic/package-lock.json
@@ -12,64 +12,8 @@
         "dotenv": "^16.3.1",
         "express": "^4.17.1",
         "renderjson": "^1.4.0",
-        "vezgo-sdk-js": "^2.0.1"
+        "vezgo-sdk-js": "^2.0.5"
       }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
-    },
-    "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
-      "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.2",
-        "fdir": "^6.2.0",
-        "is-reference": "1.2.1",
-        "magic-string": "^0.30.3",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0 || 14 >= 14.17"
-      },
-      "peerDependencies": {
-        "rollup": "^2.68.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -134,6 +78,12 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -164,11 +114,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -246,6 +191,15 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -263,11 +217,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -316,19 +265,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/finalhandler": {
@@ -487,29 +423,96 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -607,17 +610,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -699,6 +691,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -813,51 +817,17 @@
       }
     },
     "node_modules/vezgo-sdk-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.0.tgz",
-      "integrity": "sha512-W1ixXI38uAtP3+vZlcDUyT/MkKJSxQA1Ggx1GRGmVR2zHkR2uNU7vwbSf8Uk1MPS1bqpw/CWBLtqBbYNZV2HdA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.5.tgz",
+      "integrity": "sha512-nX0lYYibdQjIR312wK7qMvYgki1R7l6nrjYcfRFYWB0Nf3OR+vCrkZytjbz70HWeKb79yc3rQU8T8z0JYjbcUg==",
+      "license": "MIT",
       "dependencies": {
-        "@rollup/plugin-commonjs": "^28.0.2",
         "apisauce": "^3.0.1",
-        "jwt-decode": "^4.0.0"
+        "jsonwebtoken": "^9.0.2"
       }
     }
   },
   "dependencies": {
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
-    },
-    "@rollup/plugin-commonjs": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
-      "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
-      "requires": {
-        "@rollup/pluginutils": "^5.0.1",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.2",
-        "fdir": "^6.2.0",
-        "is-reference": "1.2.1",
-        "magic-string": "^0.30.3",
-        "picomatch": "^4.0.2"
-      }
-    },
-    "@rollup/pluginutils": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
-      "requires": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      }
-    },
-    "@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
-    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -914,6 +884,11 @@
         "unpipe": "1.0.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -935,11 +910,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -992,6 +962,14 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1006,11 +984,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "etag": {
       "version": "1.8.1",
@@ -1054,12 +1027,6 @@
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       }
-    },
-    "fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-      "requires": {}
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -1164,26 +1131,83 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
-    "is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+    "jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "requires": {
-        "@types/estree": "*"
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
-    "jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
-    },
-    "magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+    "jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "requires": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
       }
+    },
+    "jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "requires": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -1251,11 +1275,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
-    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1308,6 +1327,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="
     },
     "send": {
       "version": "0.18.0",
@@ -1397,13 +1421,12 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vezgo-sdk-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.0.tgz",
-      "integrity": "sha512-W1ixXI38uAtP3+vZlcDUyT/MkKJSxQA1Ggx1GRGmVR2zHkR2uNU7vwbSf8Uk1MPS1bqpw/CWBLtqBbYNZV2HdA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.5.tgz",
+      "integrity": "sha512-nX0lYYibdQjIR312wK7qMvYgki1R7l6nrjYcfRFYWB0Nf3OR+vCrkZytjbz70HWeKb79yc3rQU8T8z0JYjbcUg==",
       "requires": {
-        "@rollup/plugin-commonjs": "^28.0.2",
         "apisauce": "^3.0.1",
-        "jwt-decode": "^4.0.0"
+        "jsonwebtoken": "^9.0.2"
       }
     }
   }

--- a/example/basic/package-lock.json
+++ b/example/basic/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.17.1",
         "renderjson": "^1.4.0",
-        "vezgo-sdk-js": "^2.0.5"
+        "vezgo-sdk-js": "^2.0.6"
       }
     },
     "node_modules/accepts": {
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/vezgo-sdk-js": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.5.tgz",
-      "integrity": "sha512-nX0lYYibdQjIR312wK7qMvYgki1R7l6nrjYcfRFYWB0Nf3OR+vCrkZytjbz70HWeKb79yc3rQU8T8z0JYjbcUg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.6.tgz",
+      "integrity": "sha512-Dq6HgBzf28MX9OgDuyEC8QU3YvJpyomn0Y1xJzxofQvh0GDuCzbLJ9qCfpLHfribdsfG62XjosXq8DdVlsNzEQ==",
       "license": "MIT",
       "dependencies": {
         "apisauce": "^3.0.1",
@@ -1421,9 +1421,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vezgo-sdk-js": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.5.tgz",
-      "integrity": "sha512-nX0lYYibdQjIR312wK7qMvYgki1R7l6nrjYcfRFYWB0Nf3OR+vCrkZytjbz70HWeKb79yc3rQU8T8z0JYjbcUg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.6.tgz",
+      "integrity": "sha512-Dq6HgBzf28MX9OgDuyEC8QU3YvJpyomn0Y1xJzxofQvh0GDuCzbLJ9qCfpLHfribdsfG62XjosXq8DdVlsNzEQ==",
       "requires": {
         "apisauce": "^3.0.1",
         "jsonwebtoken": "^9.0.2"

--- a/example/basic/package.json
+++ b/example/basic/package.json
@@ -12,6 +12,6 @@
     "dotenv": "^16.3.1",
     "express": "^4.17.1",
     "renderjson": "^1.4.0",
-    "vezgo-sdk-js": "^2.0.4"
+    "vezgo-sdk-js": "^2.0.5"
   }
 }

--- a/example/basic/package.json
+++ b/example/basic/package.json
@@ -12,6 +12,6 @@
     "dotenv": "^16.3.1",
     "express": "^4.17.1",
     "renderjson": "^1.4.0",
-    "vezgo-sdk-js": "^2.0.5"
+    "vezgo-sdk-js": "^2.0.6"
   }
 }

--- a/example/basic/yarn.lock
+++ b/example/basic/yarn.lock
@@ -56,7 +56,7 @@ body-parser@1.20.1:
 
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 bytes@3.1.2:
@@ -130,7 +130,7 @@ dotenv@^16.3.1:
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
-  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
@@ -291,7 +291,7 @@ ipaddr.js@1.9.1:
 
 jsonwebtoken@^9.0.2:
   version "9.0.3"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz#6cd57ab01e9b0ac07cb847d53d3c9b6ee31f7ae2"
+  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz"
   integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
   dependencies:
     jws "^4.0.1"
@@ -307,7 +307,7 @@ jsonwebtoken@^9.0.2:
 
 jwa@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  resolved "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz"
   integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
   dependencies:
     buffer-equal-constant-time "^1.0.1"
@@ -316,7 +316,7 @@ jwa@^2.0.1:
 
 jws@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  resolved "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz"
   integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
   dependencies:
     jwa "^2.0.1"
@@ -324,37 +324,37 @@ jws@^4.0.1:
 
 lodash.includes@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  resolved "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
   integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
 
 lodash.isinteger@^4.0.4:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  resolved "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
   integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
 
 lodash.isnumber@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  resolved "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz"
   integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  resolved "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
 lodash.once@^4.0.0:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 media-typer@0.3.0:
@@ -389,12 +389,17 @@ mime@1.6.0:
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -466,7 +471,7 @@ renderjson@^1.4.0:
   resolved "https://registry.npmjs.org/renderjson/-/renderjson-1.4.0.tgz"
   integrity sha512-R0IZoxjWQP4XMJjLkPjNKSwjDyl20EiLohyu1Os7AvIvO4F4Vtar1N6IjJLPLjDN7OYOXTsqtIVJupQnQMvYQw==
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1:
+safe-buffer@^5.0.1, safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -477,9 +482,9 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1:
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^7.5.4:
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
-  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+  version "7.8.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz"
+  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
 
 send@0.18.0:
   version "0.18.0"
@@ -542,7 +547,7 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0, unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -557,10 +562,10 @@ vary@~1.1.2:
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vezgo-sdk-js@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/vezgo-sdk-js/-/vezgo-sdk-js-2.0.4.tgz#ea3221eca14ff38e1b0aa2a26b44a78a44caaa59"
-  integrity sha512-Xp4hjooVHuNhGfeDGptWzKnDof5gHF8fa3n/xBcFyNKMEQCgBfYkFYDXdCIdfCHYaQXTNmoY+T9e+kHAP+xzTg==
+vezgo-sdk-js@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.5.tgz"
+  integrity sha512-nX0lYYibdQjIR312wK7qMvYgki1R7l6nrjYcfRFYWB0Nf3OR+vCrkZytjbz70HWeKb79yc3rQU8T8z0JYjbcUg==
   dependencies:
     apisauce "^3.0.1"
     jsonwebtoken "^9.0.2"

--- a/example/basic/yarn.lock
+++ b/example/basic/yarn.lock
@@ -562,10 +562,10 @@ vary@~1.1.2:
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vezgo-sdk-js@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.5.tgz"
-  integrity sha512-nX0lYYibdQjIR312wK7qMvYgki1R7l6nrjYcfRFYWB0Nf3OR+vCrkZytjbz70HWeKb79yc3rQU8T8z0JYjbcUg==
+vezgo-sdk-js@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/vezgo-sdk-js/-/vezgo-sdk-js-2.0.6.tgz"
+  integrity sha512-Dq6HgBzf28MX9OgDuyEC8QU3YvJpyomn0Y1xJzxofQvh0GDuCzbLJ9qCfpLHfribdsfG62XjosXq8DdVlsNzEQ==
   dependencies:
     apisauce "^3.0.1"
     jsonwebtoken "^9.0.2"

--- a/example/react-ts/package-lock.json
+++ b/example/react-ts/package-lock.json
@@ -12,7 +12,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react18-json-view": "^0.2.8",
-        "vezgo-sdk-js": "^2.0.0"
+        "vezgo-sdk-js": "^2.0.6"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -25,12 +25,11 @@
       }
     },
     "../..": {
-      "version": "2.0.0",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
-        "@rollup/plugin-commonjs": "^28.0.2",
         "apisauce": "^3.0.1",
-        "jwt-decode": "^4.0.0"
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.6",
@@ -42,10 +41,8 @@
         "eslint": "^9.3.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.29.1",
-        "jsonwebtoken": "^8.5.1",
         "prettier": "^2.7.1",
         "vite": "^6.2.0",
-        "vite-plugin-commonjs": "^0.10.1",
         "vite-plugin-node-polyfills": "^0.23.0",
         "vite-plugin-static-copy": "^1.0.5",
         "vitest": "^1.6.0"

--- a/example/react-ts/package.json
+++ b/example/react-ts/package.json
@@ -13,7 +13,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react18-json-view": "^0.2.8",
-    "vezgo-sdk-js": "^2.0.3"
+    "vezgo-sdk-js": "^2.0.6"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vezgo-sdk-js",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Official Vezgo JS SDK for the Browser & NodeJS",
   "author": "Wealthica Financial Technology Inc. <hello@wealthica.com> (https://wealthica.com/)",
   "license": "MIT",

--- a/src/api.js
+++ b/src/api.js
@@ -16,6 +16,22 @@ const CALLBACK_CONNECTION = '_onConnection';
 const CALLBACK_ERROR = '_onError';
 const CALLBACK_EVENT = '_onEvent';
 
+// ERROR types from the Connect widget that should terminate the flow (close the widget and call
+// onError). Any ERROR type not in this list is forwarded to onEvent as a notification, leaving the
+// widget open so the user can recover in-place (e.g. retry credentials, answer a 2FA question).
+const TERMINAL_ERROR_TYPES = [
+  'DUPLICATE_CONNECTION',
+  'CLIENT_ID_REQUIRED',
+  'WRONG_CLIENT_ID',
+  'INVALID_ORIGIN',
+  'TOKEN_REQUIRED',
+  'WRONG_REDIRECT_URI',
+  'INVALID_ACCOUNT_ID',
+  'PAGE_NOT_FOUND',
+  'SESSION_EXPIRED',
+  'INVALID_TOKEN',
+];
+
 class API {
   constructor(config) {
     this.config = { ...config };
@@ -386,7 +402,14 @@ class API {
       case 'ERROR': {
         // Structured error event with a typed payload (e.g. DUPLICATE_CONNECTION).
         // result.data = { type, existing_institution_id, error, ... }
-        this._triggerCallback(CALLBACK_ERROR, result.data);
+        // Only types in TERMINAL_ERROR_TYPES close the widget — non-terminal ones (e.g.
+        // INVALID_CREDENTIALS, SECURITY_QUESTION_REQUIRED) are notifications; the widget UI
+        // continues to let the user recover in-place.
+        if (TERMINAL_ERROR_TYPES.includes(result.data && result.data.type)) {
+          this._triggerCallback(CALLBACK_ERROR, result.data);
+        } else {
+          this._triggerCallback(CALLBACK_EVENT, result);
+        }
         break;
       }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,9 +4,10 @@ export = Vezgo;
 
 export declare var Vezgo: {
   init(config: APIConfig): APIInterface;
+  DuplicateConnectionError: typeof DuplicateConnectionError;
 };
 
-export declare class DuplicateConnectionError extends Error {
+declare class DuplicateConnectionError extends Error {
   name: 'DuplicateConnectionError';
   /** The Vezgo account ID of the already-linked connection that caused the conflict. */
   existing_institution_id: string;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import API from './api';
-export { DuplicateConnectionError } from './errors';
+import { DuplicateConnectionError } from './errors';
 
 class Vezgo {
-   
   init(config = {}) {
     const api = new API(config);
 
@@ -10,4 +9,7 @@ class Vezgo {
   }
 }
 
-export default new Vezgo();
+const vezgo = new Vezgo();
+vezgo.DuplicateConnectionError = DuplicateConnectionError;
+
+export default vezgo;

--- a/vite.config.browser.mjs
+++ b/vite.config.browser.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
           dir: 'dist',
           entryFileNames: 'vezgo.umd.js',
           name: 'Vezgo',
+          exports: 'default',
         },
       ]
     },

--- a/vite.config.node.mjs
+++ b/vite.config.node.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
           format: 'cjs',
           dir: 'dist',
           entryFileNames: 'vezgo.cjs.js',
+          exports: 'default',
         },
       ]
     },


### PR DESCRIPTION
## Summary
- Restore pre-2.0.4 widget behaviour: non-terminal ERROR events (`INVALID_CREDENTIALS`, `SECURITY_QUESTION_REQUIRED`, etc.) now go to `onEvent` and leave the widget open
- Restore singleton-as-module-export: `require('vezgo-sdk-js').init(...)` works again without the `.default` workaround
- 5 regression tests added covering terminal vs non-terminal `ERROR` routing

## Root cause
- **Widget close**: commit ca98ee2 (PR #97 "Adding support for duplicate account", shipped in 2.0.4) added `case 'ERROR':` in `_onMessage` that routes ALL typed `ERROR` events to `onError` and closes the widget. The vezgo-app Connect widget (since Aug 2025, vezgo-app PR #752) sends `ERROR` events for many *non-terminal* flow states (e.g. `INVALID_CREDENTIALS`, `SECURITY_QUESTION_REQUIRED`, `TIMEOUT_ERROR`) purely as notifications — 2.0.4+ treats them all as terminal, breaking inline credential retry.
- **CJS/UMD interop**: `src/index.js` had both `export default` and a named re-export, so Rollup emitted `exports.default = …; exports.DuplicateConnectionError = …`. `Vezgo.init` was undefined on `require('vezgo-sdk-js')`; consumers had to use `.default`.

## Changes
- `src/api.js` — `TERMINAL_ERROR_TYPES` whitelist (`DUPLICATE_CONNECTION`, `CLIENT_ID_REQUIRED`, `WRONG_CLIENT_ID`, `INVALID_ORIGIN`, `TOKEN_REQUIRED`, `WRONG_REDIRECT_URI`, `INVALID_ACCOUNT_ID`, `PAGE_NOT_FOUND`, `SESSION_EXPIRED`, `INVALID_TOKEN`); non-terminal types fall through to `onEvent`
- `src/index.js` — attach `DuplicateConnectionError` as a property of the singleton; drop the named ESM re-export
- `src/index.d.ts` — expose `DuplicateConnectionError` under the `Vezgo` namespace
- `vite.config.node.mjs` — `exports: 'default'` on the CJS output → `module.exports = vezgo`
- `vite.config.browser.mjs` — `exports: 'default'` on the UMD output → `window.Vezgo = vezgo`
- `__tests__/user.instance.browser.js` — 5 regression tests
- `example/basic/*` — pre-existing working-tree bump to `^2.0.5` (carried along; `^` satisfies 2.0.6 once published)

## Affected versions
| Version | Released | Affected? |
|---|---|---|
| 2.0.3 | 2025-03-11 | No |
| **2.0.4** | **2026-04-24** | **Yes (first broken)** |
| 2.0.5 | 2026-05-05 | Yes |

The Vezgo demo at `vezgo.com/demo` still works because vezgo-site pins 2.0.3 in its lockfile (last redeployed 2026-03-20).

**Target release: 2.0.6**

## Test plan
- [x] `yarn test` — 111 passing (was 106)
- [x] `yarn lint` — no new errors from this change
- [x] `yarn build` — CJS bundle ends with `module.exports = vezgo`; UMD wrapper does `module.exports = factory()` / `window.Vezgo = factory()`
- [x] Smoke test on `dist/vezgo.cjs.js`: `V.init` is a function, `V.DuplicateConnectionError` is a class
- [ ] Post-publish: in a fresh consumer install of 2.0.6, `require('vezgo-sdk-js').init(...)` works; Connect widget stays open on `INVALID_CREDENTIALS` and allows credential retry

## Breaking change (tiny)
ESM consumers using `import { DuplicateConnectionError } from 'vezgo-sdk-js'` must switch to `import Vezgo from 'vezgo-sdk-js'; new Vezgo.DuplicateConnectionError(...)`. Since the named export only shipped in 2.0.4/2.0.5 (the broken versions), real-world impact is essentially nil.

[VP-999](https://app.clickup.com/t/9018965231/VP-999)